### PR TITLE
Use in-memory deletion keys

### DIFF
--- a/static/js/download.js
+++ b/static/js/download.js
@@ -95,7 +95,9 @@ upload.modules.addmodule({
         if (!stored) {
             try {
                 stored = localStorage.getItem('delete-' + data.ident)
-            } catch (e) {}
+            } catch (e) {
+                console.log(e)
+            }
         }
 
         if (stored && !isiframed()) {

--- a/static/js/download.js
+++ b/static/js/download.js
@@ -1,5 +1,6 @@
 upload.modules.addmodule({
     name: 'download',
+    delkeys: {},
     // Dear santa, https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/template_strings
     template: '\
       <div class="modulecontent" id="dlarea">\
@@ -89,7 +90,13 @@ upload.modules.addmodule({
         this._.filename.text(data.header.name)
         this._.title.text(data.header.name + ' - Up1')
 
-        var stored = localStorage.getItem('delete-' + data.ident)
+        var stored = this.delkeys[data.ident]
+
+        if (!stored) {
+            try {
+                stored = localStorage.getItem('delete-' + data.ident)
+            } catch (e) {}
+        }
 
         if (stored && !isiframed()) {
             this._.deletebtn.show().prop('href', (upload.config.server ? upload.config.server : '') + 'del?delkey=' + stored + '&ident=' + data.ident)

--- a/static/js/home.js
+++ b/static/js/home.js
@@ -140,7 +140,9 @@ upload.modules.addmodule({
         
         try {
             localStorage.setItem('delete-' + data.ident, response.delkey)
-        } catch (e) {}
+        } catch (e) {
+            console.log(e)
+        }
 
         if (window.location.hash == '#noref') {
             history.replaceState(undefined, undefined, '#' + data.seed)

--- a/static/js/home.js
+++ b/static/js/home.js
@@ -136,7 +136,12 @@ upload.modules.addmodule({
         upload.textpaste.render(this._.view, 'Pasted text.txt', data, 'text/plain', this.closepaste.bind(this))
     },
     uploaded: function (data, response) {
-        localStorage.setItem('delete-' + data.ident, response.delkey)
+        upload.download.delkeys[data.ident] = response.delkey
+        
+        try {
+            localStorage.setItem('delete-' + data.ident, response.delkey)
+        } catch (e) {}
+
         if (window.location.hash == '#noref') {
             history.replaceState(undefined, undefined, '#' + data.seed)
             upload.route.setroute(upload.download, undefined, data.seed)


### PR DESCRIPTION
Store del keys in memory and only fall back to local storage.
Catch local storage exceptions (Disabled, corrupt, etc).